### PR TITLE
Add formatUSDText

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is a [Firebot](https://firebot.app) plugin that adds utility replacement va
 - **`$filenamesInDirectory`**: Returns some or all filenames in a given directory, ignoring subdirectories and not recursing.
 - **`$flattenArray`**: Flattens nested arrays and objects into a single-level array, with configurable depth limit.
 - **`$formatUSD`**: Converts a number to US dollar currency format with optional division and thousands separators. [Reference](/doc/reference/format-usd.md)
+- **`$formatUSDText`**: Converts a dollar amount to English words optimized for text-to-speech (TTS). Supports amounts from -10 trillion to 10 trillion inclusive. [Reference](/doc/reference/format-usd-text.md)
 - **`$haversineDistance`**: Calculates the distance in meters between two geographic coordinates using the Haversine formula.
 - **`$metersToMiles`**: Converts a distance in meters to miles.
 - **`$milesToMeters`**: Converts a distance in miles to meters.
@@ -27,6 +28,7 @@ This is a [Firebot](https://firebot.app) plugin that adds utility replacement va
 - [Installation](/doc/installation.md)
 - [Upgrading](/doc/upgrading.md)
 - [Format USD Reference](/doc/reference/format-usd.md)
+- [Format USD Text Reference](/doc/reference/format-usd-text.md)
 
 ## Support
 

--- a/doc/reference/format-usd-text.md
+++ b/doc/reference/format-usd-text.md
@@ -1,0 +1,355 @@
+# $formatUSDText
+
+## Table of Contents
+
+- [Introduction](#introduction)
+- [Usage](#usage)
+- [Parameters](#parameters)
+- [Returns](#returns)
+- [Supported Range](#supported-range)
+- [Examples](#examples)
+- [Related Variables](#related-variables)
+
+## Introduction
+
+The `$formatUSDText` replace variable converts a dollar amount to English words optimized for text-to-speech (TTS) systems. This is useful for reading currency amounts aloud naturally, with proper hyphenation, singular/plural forms, and optional cent handling. It supports optional division before converting and handles amounts up to ±10 trillion.
+
+## Usage
+
+```text
+$formatUSDText[amount]
+$formatUSDText[amount, divisor]
+```
+
+## Parameters
+
+**amount** (required)
+
+- Type: number or string
+- The amount to convert to words
+- String inputs are cleaned of non-numeric characters (except digits, minus sign, and decimal point)
+- Invalid values are treated as 0
+
+**divisor** (optional, default: 1)
+
+- Type: number or string
+- Divides the amount before converting to words
+- String inputs are cleaned of non-numeric characters (except digits, minus sign, and decimal point)
+- Invalid values or zero are treated as 1
+
+## Returns
+
+A string containing the English word representation of the dollar amount, formatted for natural text-to-speech reading.
+
+**Characteristics:**
+
+- Numbers 21-99 use hyphens (e.g., "twenty-one", "ninety-nine")
+- Singular "dollar" or "cent" for 1, plural for all other amounts
+- When dollars are zero and cents are present, only cents are output (no "zero dollars and")
+- Zero cents are omitted from output
+- Cents are preceded with "and" when dollars are present
+- Negative amounts are prefixed with "negative"
+- Scale words (thousand, million, billion, trillion) are properly spaced
+
+## Supported Range
+
+The supported range is **-10 trillion to 10 trillion inclusive**:
+
+- **Minimum:** -10,000,000,000,000.00 (negative ten trillion)
+- **Maximum:** 10,000,000,000,000.00 (ten trillion)
+
+Amounts outside this range return an empty string.
+
+This range is limited by JavaScript's number precision and ensures accurate conversion without floating-point rounding errors.
+
+## Examples
+
+### Basic formatting
+
+```text
+$formatUSDText[0]
+```
+
+Returns: `zero dollars`
+
+```text
+$formatUSDText[1]
+```
+
+Returns: `one dollar`
+
+```text
+$formatUSDText[5]
+```
+
+Returns: `five dollars`
+
+### Compound numbers with hyphens
+
+```text
+$formatUSDText[21]
+```
+
+Returns: `twenty-one dollars`
+
+```text
+$formatUSDText[99]
+```
+
+Returns: `ninety-nine dollars`
+
+### Hundreds
+
+```text
+$formatUSDText[100]
+```
+
+Returns: `one hundred dollars`
+
+```text
+$formatUSDText[123]
+```
+
+Returns: `one hundred twenty-three dollars`
+
+### Thousands
+
+```text
+$formatUSDText[1000]
+```
+
+Returns: `one thousand dollars`
+
+```text
+$formatUSDText[1234]
+```
+
+Returns: `one thousand two hundred thirty-four dollars`
+
+```text
+$formatUSDText[420000]
+```
+
+Returns: `four hundred twenty thousand dollars`
+
+### Millions
+
+```text
+$formatUSDText[1000000]
+```
+
+Returns: `one million dollars`
+
+```text
+$formatUSDText[1234567]
+```
+
+Returns: `one million two hundred thirty-four thousand five hundred sixty-seven dollars`
+
+### Billions
+
+```text
+$formatUSDText[1000000000]
+```
+
+Returns: `one billion dollars`
+
+```text
+$formatUSDText[10000000000]
+```
+
+Returns: `ten billion dollars`
+
+### Trillions (maximum scale)
+
+```text
+$formatUSDText[1000000000000]
+```
+
+Returns: `one trillion dollars`
+
+```text
+$formatUSDText[5000000000000]
+```
+
+Returns: `five trillion dollars`
+
+```text
+$formatUSDText[10000000000000]
+```
+
+Returns: `ten trillion dollars`
+
+### Range boundaries
+
+```text
+$formatUSDText[10000000000000]
+```
+
+Returns: `ten trillion dollars` (maximum)
+
+```text
+$formatUSDText[10000000000000.00]
+```
+
+Returns: `ten trillion dollars` (maximum with zero cents)
+
+```text
+$formatUSDText[-10000000000000]
+```
+
+Returns: `negative ten trillion dollars` (minimum)
+
+```text
+$formatUSDText[10000000000001]
+```
+
+Returns: `` (empty string, exceeds maximum)
+
+```text
+$formatUSDText[-10000000000001]
+```
+
+Returns: `` (empty string, exceeds minimum)
+
+### Decimal/Cents handling
+
+```text
+$formatUSDText[0.01]
+```
+
+Returns: `one cent`
+
+```text
+$formatUSDText[0.69]
+```
+
+Returns: `sixty-nine cents`
+
+```text
+$formatUSDText[420.69]
+```
+
+Returns: `four hundred twenty dollars and sixty-nine cents`
+
+```text
+$formatUSDText[100.00]
+```
+
+Returns: `one hundred dollars` (omits zero cents)
+
+### Singular forms
+
+```text
+$formatUSDText[1.01]
+```
+
+Returns: `one dollar and one cent` (singular for both)
+
+```text
+$formatUSDText[2.01]
+```
+
+Returns: `two dollars and one cent` (plural dollars, singular cent)
+
+### Negative amounts
+
+```text
+$formatUSDText[-5]
+```
+
+Returns: `negative five dollars`
+
+```text
+$formatUSDText[-200.4]
+```
+
+Returns: `negative two hundred dollars and forty cents`
+
+```text
+$formatUSDText[-10000000000000]
+```
+
+Returns: `negative ten trillion dollars`
+
+### Division
+
+```text
+$formatUSDText[100, 2]
+```
+
+Returns: `fifty dollars`
+
+```text
+$formatUSDText[10000, 100]
+```
+
+Returns: `one hundred dollars` (typical bits-to-dollars conversion: 10000 bits ÷ 100 = $100)
+
+```text
+$formatUSDText[150, 100]
+```
+
+Returns: `one dollar and fifty cents` (150 bits ÷ 100 = $1.50)
+
+### String inputs with special characters
+
+```text
+$formatUSDText[$420.69]
+```
+
+Returns: `four hundred twenty dollars and sixty-nine cents`
+
+```text
+$formatUSDText[1,234.56]
+```
+
+Returns: `one thousand two hundred thirty-four dollars and fifty-six cents`
+
+```text
+$formatUSDText[-$100.00]
+```
+
+Returns: `negative one hundred dollars`
+
+### Real-world scenarios
+
+Convert streamer bits to dollars:
+
+```text
+$formatUSDText[5000, 100]
+```
+
+Returns: `fifty dollars`
+
+Convert large amounts:
+
+```text
+$formatUSDText[123456789.99]
+```
+
+Returns: `one hundred twenty-three million four hundred fifty-six thousand seven hundred eighty-nine dollars and ninety-nine cents`
+
+### Invalid inputs
+
+```text
+$formatUSDText[abc]
+```
+
+Returns: `zero dollars`
+
+```text
+$formatUSDText[100, 0]
+```
+
+Returns: `one hundred dollars` (zero divisor treated as 1)
+
+```text
+$formatUSDText[10000000000001]
+```
+
+Returns: `` (empty string, exceeds 10 trillion maximum)
+
+## Related Variables
+
+- **`$formatUSD`**: Formats numbers as USD currency with dollar sign (e.g., `$420.69`)

--- a/src/variables/__tests__/format-usd-text.test.ts
+++ b/src/variables/__tests__/format-usd-text.test.ts
@@ -1,0 +1,652 @@
+import type { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effects";
+import model from "../format-usd-text";
+
+const mockTrigger = {} as unknown as Effects.Trigger;
+
+describe("formatUSDText variable", () => {
+    describe("definition", () => {
+        it("should have correct handle", () => {
+            expect(model.definition.handle).toBe("formatUSDText");
+        });
+
+        it("should have correct usage", () => {
+            expect(model.definition.usage).toBe("formatUSDText[amount, divisor]");
+        });
+
+        it("should have categories", () => {
+            expect(model.definition.categories).toContain("advanced");
+        });
+
+        it("should have text as possible data output", () => {
+            expect(model.definition.possibleDataOutput).toContain("text");
+        });
+
+        it("should have examples", () => {
+            expect(model.definition.examples).toBeDefined();
+            expect(model.definition.examples).toBeDefined();
+            expect(model.definition.examples?.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe("evaluator function", () => {
+        describe("basic ones (0-19)", () => {
+            it("should convert zero to words", () => {
+                const result = model.evaluator(mockTrigger, 0);
+                expect(result).toBe("zero dollars");
+            });
+
+            it("should convert one to words", () => {
+                const result = model.evaluator(mockTrigger, 1);
+                expect(result).toBe("one dollar");
+            });
+
+            it("should convert one with correct singular", () => {
+                const result = model.evaluator(mockTrigger, 1.0);
+                expect(result).toBe("one dollar");
+            });
+
+            it("should convert two to words", () => {
+                const result = model.evaluator(mockTrigger, 2);
+                expect(result).toBe("two dollars");
+            });
+
+            it("should convert five to words", () => {
+                const result = model.evaluator(mockTrigger, 5);
+                expect(result).toBe("five dollars");
+            });
+
+            it("should convert nine to words", () => {
+                const result = model.evaluator(mockTrigger, 9);
+                expect(result).toBe("nine dollars");
+            });
+
+            it("should convert ten to words", () => {
+                const result = model.evaluator(mockTrigger, 10);
+                expect(result).toBe("ten dollars");
+            });
+
+            it("should convert eleven to words", () => {
+                const result = model.evaluator(mockTrigger, 11);
+                expect(result).toBe("eleven dollars");
+            });
+
+            it("should convert fifteen to words", () => {
+                const result = model.evaluator(mockTrigger, 15);
+                expect(result).toBe("fifteen dollars");
+            });
+
+            it("should convert nineteen to words", () => {
+                const result = model.evaluator(mockTrigger, 19);
+                expect(result).toBe("nineteen dollars");
+            });
+        });
+
+        describe("tens and compound numbers (20-99)", () => {
+            it("should convert twenty to words", () => {
+                const result = model.evaluator(mockTrigger, 20);
+                expect(result).toBe("twenty dollars");
+            });
+
+            it("should convert twenty-one with hyphen", () => {
+                const result = model.evaluator(mockTrigger, 21);
+                expect(result).toBe("twenty-one dollars");
+            });
+
+            it("should convert twenty-nine with hyphen", () => {
+                const result = model.evaluator(mockTrigger, 29);
+                expect(result).toBe("twenty-nine dollars");
+            });
+
+            it("should convert thirty to words", () => {
+                const result = model.evaluator(mockTrigger, 30);
+                expect(result).toBe("thirty dollars");
+            });
+
+            it("should convert thirty-five with hyphen", () => {
+                const result = model.evaluator(mockTrigger, 35);
+                expect(result).toBe("thirty-five dollars");
+            });
+
+            it("should convert fifty to words", () => {
+                const result = model.evaluator(mockTrigger, 50);
+                expect(result).toBe("fifty dollars");
+            });
+
+            it("should convert fifty-five with hyphen", () => {
+                const result = model.evaluator(mockTrigger, 55);
+                expect(result).toBe("fifty-five dollars");
+            });
+
+            it("should convert ninety to words", () => {
+                const result = model.evaluator(mockTrigger, 90);
+                expect(result).toBe("ninety dollars");
+            });
+
+            it("should convert ninety-nine with hyphen", () => {
+                const result = model.evaluator(mockTrigger, 99);
+                expect(result).toBe("ninety-nine dollars");
+            });
+        });
+
+        describe("hundreds (100-999)", () => {
+            it("should convert one hundred to words", () => {
+                const result = model.evaluator(mockTrigger, 100);
+                expect(result).toBe("one hundred dollars");
+            });
+
+            it("should convert one hundred one to words", () => {
+                const result = model.evaluator(mockTrigger, 101);
+                expect(result).toBe("one hundred one dollars");
+            });
+
+            it("should convert one hundred twenty-three to words", () => {
+                const result = model.evaluator(mockTrigger, 123);
+                expect(result).toBe("one hundred twenty-three dollars");
+            });
+
+            it("should convert two hundred to words", () => {
+                const result = model.evaluator(mockTrigger, 200);
+                expect(result).toBe("two hundred dollars");
+            });
+
+            it("should convert five hundred fifty-five to words", () => {
+                const result = model.evaluator(mockTrigger, 555);
+                expect(result).toBe("five hundred fifty-five dollars");
+            });
+
+            it("should convert nine hundred ninety-nine to words", () => {
+                const result = model.evaluator(mockTrigger, 999);
+                expect(result).toBe("nine hundred ninety-nine dollars");
+            });
+        });
+
+        describe("thousands (1000-999999)", () => {
+            it("should convert one thousand to words", () => {
+                const result = model.evaluator(mockTrigger, 1000);
+                expect(result).toBe("one thousand dollars");
+            });
+
+            it("should convert one thousand one to words", () => {
+                const result = model.evaluator(mockTrigger, 1001);
+                expect(result).toBe("one thousand one dollars");
+            });
+
+            it("should convert one thousand two hundred thirty-four to words", () => {
+                const result = model.evaluator(mockTrigger, 1234);
+                expect(result).toBe("one thousand two hundred thirty-four dollars");
+            });
+
+            it("should convert ten thousand to words", () => {
+                const result = model.evaluator(mockTrigger, 10000);
+                expect(result).toBe("ten thousand dollars");
+            });
+
+            it("should convert one hundred thousand to words", () => {
+                const result = model.evaluator(mockTrigger, 100000);
+                expect(result).toBe("one hundred thousand dollars");
+            });
+
+            it("should convert four hundred twenty thousand to words", () => {
+                const result = model.evaluator(mockTrigger, 420000);
+                expect(result).toBe("four hundred twenty thousand dollars");
+            });
+
+            it("should convert nine hundred ninety-nine thousand nine hundred ninety-nine to words", () => {
+                const result = model.evaluator(mockTrigger, 999999);
+                expect(result).toBe(
+                    "nine hundred ninety-nine thousand nine hundred ninety-nine dollars"
+                );
+            });
+        });
+
+        describe("millions (1000000-999999999)", () => {
+            it("should convert one million to words", () => {
+                const result = model.evaluator(mockTrigger, 1000000);
+                expect(result).toBe("one million dollars");
+            });
+
+            it("should convert one million one to words", () => {
+                const result = model.evaluator(mockTrigger, 1000001);
+                expect(result).toBe("one million one dollars");
+            });
+
+            it("should convert one million two hundred thirty-four thousand five hundred sixty-seven to words", () => {
+                const result = model.evaluator(mockTrigger, 1234567);
+                expect(result).toBe(
+                    "one million two hundred thirty-four thousand five hundred sixty-seven dollars"
+                );
+            });
+
+            it("should convert ten million to words", () => {
+                const result = model.evaluator(mockTrigger, 10000000);
+                expect(result).toBe("ten million dollars");
+            });
+
+            it("should convert one hundred million to words", () => {
+                const result = model.evaluator(mockTrigger, 100000000);
+                expect(result).toBe("one hundred million dollars");
+            });
+
+            it("should convert nine hundred ninety-nine million nine hundred ninety-nine thousand nine hundred ninety-nine to words", () => {
+                const result = model.evaluator(mockTrigger, 999999999);
+                expect(result).toBe(
+                    "nine hundred ninety-nine million nine hundred ninety-nine thousand nine hundred ninety-nine dollars"
+                );
+            });
+        });
+
+        describe("billions (1000000000-999999999999)", () => {
+            it("should convert one billion to words", () => {
+                const result = model.evaluator(mockTrigger, 1000000000);
+                expect(result).toBe("one billion dollars");
+            });
+
+            it("should convert one billion one to words", () => {
+                const result = model.evaluator(mockTrigger, 1000000001);
+                expect(result).toBe("one billion one dollars");
+            });
+
+            it("should convert ten billion to words", () => {
+                const result = model.evaluator(mockTrigger, 10000000000);
+                expect(result).toBe("ten billion dollars");
+            });
+
+            it("should convert one hundred billion to words", () => {
+                const result = model.evaluator(mockTrigger, 100000000000);
+                expect(result).toBe("one hundred billion dollars");
+            });
+        });
+
+        describe("trillions (1000000000000-10000000000000)", () => {
+            it("should convert one trillion to words", () => {
+                const result = model.evaluator(mockTrigger, 1000000000000);
+                expect(result).toBe("one trillion dollars");
+            });
+
+            it("should convert five trillion to words", () => {
+                const result = model.evaluator(mockTrigger, 5000000000000);
+                expect(result).toBe("five trillion dollars");
+            });
+
+            it("should convert ten trillion to words", () => {
+                const result = model.evaluator(mockTrigger, 10000000000000);
+                expect(result).toBe("ten trillion dollars");
+            });
+
+            it("should convert nine trillion nine hundred ninety-nine billion... to words", () => {
+                const result = model.evaluator(mockTrigger, 9999999999999);
+                expect(result).toBe(
+                    "nine trillion nine hundred ninety-nine billion nine hundred ninety-nine million nine hundred ninety-nine thousand nine hundred ninety-nine dollars"
+                );
+            });
+        });
+
+        describe("decimal/cents handling", () => {
+            it("should include cents when present", () => {
+                const result = model.evaluator(mockTrigger, 1.01);
+                expect(result).toBe("one dollar and one cent");
+            });
+
+            it('should use singular "cent" for one cent', () => {
+                const result = model.evaluator(mockTrigger, 0.01);
+                expect(result).toBe("one cent");
+            });
+
+            it('should use plural "cents" for multiple cents', () => {
+                const result = model.evaluator(mockTrigger, 0.25);
+                expect(result).toBe("twenty-five cents");
+            });
+
+            it("should convert 0.4 dollars to 40 cents", () => {
+                const result = model.evaluator(mockTrigger, 0.4);
+                expect(result).toBe("forty cents");
+            });
+
+            it("should convert 69 cents to words", () => {
+                const result = model.evaluator(mockTrigger, 0.69);
+                expect(result).toBe("sixty-nine cents");
+            });
+
+            it("should convert 99 cents to words", () => {
+                const result = model.evaluator(mockTrigger, 0.99);
+                expect(result).toBe("ninety-nine cents");
+            });
+
+            it("should omit cents when zero", () => {
+                const result = model.evaluator(mockTrigger, 100.0);
+                expect(result).toBe("one hundred dollars");
+            });
+
+            it("should omit zero cents for compound amounts", () => {
+                const result = model.evaluator(mockTrigger, 420.0);
+                expect(result).toBe("four hundred twenty dollars");
+            });
+
+            it("should include cents in compound amounts", () => {
+                const result = model.evaluator(mockTrigger, 420.69);
+                expect(result).toBe("four hundred twenty dollars and sixty-nine cents");
+            });
+
+            it("should handle single cent", () => {
+                const result = model.evaluator(mockTrigger, 5.01);
+                expect(result).toBe("five dollars and one cent");
+            });
+
+            it("should handle high cents with compound dollars", () => {
+                const result = model.evaluator(mockTrigger, 1234.56);
+                expect(result).toBe(
+                    "one thousand two hundred thirty-four dollars and fifty-six cents"
+                );
+            });
+        });
+
+        describe("negative numbers", () => {
+            it('should prefix negative one dollar with "negative"', () => {
+                const result = model.evaluator(mockTrigger, -1);
+                expect(result).toBe("negative one dollar");
+            });
+
+            it('should prefix negative two dollars with "negative"', () => {
+                const result = model.evaluator(mockTrigger, -2);
+                expect(result).toBe("negative two dollars");
+            });
+
+            it('should prefix negative hundreds with "negative"', () => {
+                const result = model.evaluator(mockTrigger, -100);
+                expect(result).toBe("negative one hundred dollars");
+            });
+
+            it("should prefix negative hundreds with cents", () => {
+                const result = model.evaluator(mockTrigger, -200.4);
+                expect(result).toBe("negative two hundred dollars and forty cents");
+            });
+
+            it("should handle negative with one cent", () => {
+                const result = model.evaluator(mockTrigger, -0.01);
+                expect(result).toBe("negative one cent");
+            });
+
+            it('should prefix negative millions with "negative"', () => {
+                const result = model.evaluator(mockTrigger, -5000000);
+                expect(result).toBe("negative five million dollars");
+            });
+
+            it("should prefix negative with all scale words", () => {
+                const result = model.evaluator(mockTrigger, -1234567890);
+                expect(result).toBe(
+                    "negative one billion two hundred thirty-four million five hundred sixty-seven thousand eight hundred ninety dollars"
+                );
+            });
+
+            it("should handle negative ten trillion", () => {
+                const result = model.evaluator(mockTrigger, -10000000000000);
+                expect(result).toBe("negative ten trillion dollars");
+            });
+
+            it("should return 'zero dollars' for negative zero", () => {
+                const result = model.evaluator(mockTrigger, -0);
+                expect(result).toBe("zero dollars");
+            });
+
+            it("should return 'zero dollars' for negative zero string", () => {
+                const result = model.evaluator(mockTrigger, "-0.00");
+                expect(result).toBe("zero dollars");
+            });
+
+            it("should return 'zero dollars' for zero with negative divisor", () => {
+                const result = model.evaluator(mockTrigger, 0, -2);
+                expect(result).toBe("zero dollars");
+            });
+        });
+
+        describe("divisor parameter", () => {
+            it("should divide amount by divisor", () => {
+                const result = model.evaluator(mockTrigger, 100, 2);
+                expect(result).toBe("fifty dollars");
+            });
+
+            it("should divide 10000 by 100 to get 100 dollars", () => {
+                const result = model.evaluator(mockTrigger, 10000, 100);
+                expect(result).toBe("one hundred dollars");
+            });
+
+            it("should divide with cents result", () => {
+                const result = model.evaluator(mockTrigger, 100, 3);
+                expect(result).toBe("thirty-three dollars and thirty-three cents");
+            });
+
+            it("should divide to produce cents", () => {
+                const result = model.evaluator(mockTrigger, 25, 100);
+                expect(result).toBe("twenty-five cents");
+            });
+
+            it("should handle divisor of one", () => {
+                const result = model.evaluator(mockTrigger, 100, 1);
+                expect(result).toBe("one hundred dollars");
+            });
+
+            it("should handle string divisor", () => {
+                const result = model.evaluator(mockTrigger, 100, "2");
+                expect(result).toBe("fifty dollars");
+            });
+
+            it("should handle decimal divisor", () => {
+                const result = model.evaluator(mockTrigger, 100, 2.5);
+                expect(result).toBe("forty dollars");
+            });
+        });
+
+        describe("string input conversion", () => {
+            it("should convert string number to words", () => {
+                const result = model.evaluator(mockTrigger, "123.45");
+                expect(result).toBe(
+                    "one hundred twenty-three dollars and forty-five cents"
+                );
+            });
+
+            it("should convert string integer to words", () => {
+                const result = model.evaluator(mockTrigger, "42");
+                expect(result).toBe("forty-two dollars");
+            });
+
+            it("should handle string with dollar sign", () => {
+                const result = model.evaluator(mockTrigger, "$100");
+                expect(result).toBe("one hundred dollars");
+            });
+
+            it("should handle string with commas", () => {
+                const result = model.evaluator(mockTrigger, "1,234.56");
+                expect(result).toBe(
+                    "one thousand two hundred thirty-four dollars and fifty-six cents"
+                );
+            });
+
+            it("should handle string with whitespace", () => {
+                const result = model.evaluator(mockTrigger, "  100  ");
+                expect(result).toBe("one hundred dollars");
+            });
+
+            it("should clean string with dollar sign and commas", () => {
+                const result = model.evaluator(mockTrigger, "$1,234.56");
+                expect(result).toBe(
+                    "one thousand two hundred thirty-four dollars and fifty-six cents"
+                );
+            });
+
+            it("should clean string with negative and dollar sign", () => {
+                const result = model.evaluator(mockTrigger, "-$100.00");
+                expect(result).toBe("negative one hundred dollars");
+            });
+        });
+
+        describe("edge cases for invalid inputs", () => {
+            it("should treat undefined as zero dollars", () => {
+                const result = model.evaluator(mockTrigger, undefined);
+                expect(result).toBe("zero dollars");
+            });
+
+            it("should treat null as zero dollars", () => {
+                // biome-ignore lint/suspicious/noExplicitAny: Needed for this test
+                const result = model.evaluator(mockTrigger, null as any);
+                expect(result).toBe("zero dollars");
+            });
+
+            it("should treat empty string as zero dollars", () => {
+                const result = model.evaluator(mockTrigger, "");
+                expect(result).toBe("zero dollars");
+            });
+
+            it("should treat non-numeric string as zero dollars", () => {
+                const result = model.evaluator(mockTrigger, "abc");
+                expect(result).toBe("zero dollars");
+            });
+
+            it("should treat NaN as zero dollars", () => {
+                const result = model.evaluator(mockTrigger, NaN);
+                expect(result).toBe("zero dollars");
+            });
+
+            it("should use singular 'dollar' for exactly one dollar", () => {
+                const result = model.evaluator(mockTrigger, 1.0);
+                expect(result).toBe("one dollar");
+            });
+
+            it("should use plural 'dollars' for zero dollars", () => {
+                const result = model.evaluator(mockTrigger, 0);
+                expect(result).toBe("zero dollars");
+            });
+
+            it("should use plural 'dollars' for two dollars", () => {
+                const result = model.evaluator(mockTrigger, 2.0);
+                expect(result).toBe("two dollars");
+            });
+
+            it("should return empty string for numbers too large to convert", () => {
+                const result = model.evaluator(mockTrigger, 10000000000001);
+                expect(result).toBe("");
+            });
+
+            it("should return empty string for numbers too small to convert", () => {
+                const result = model.evaluator(mockTrigger, -10000000000001);
+                expect(result).toBe("");
+            });
+
+            it("should work with numbers at the top of the range", () => {
+                const result = model.evaluator(mockTrigger, 10000000000000);
+                expect(result).toBe("ten trillion dollars");
+            });
+
+            it("should work with numbers at the bottom of the range", () => {
+                const result = model.evaluator(mockTrigger, -10000000000000);
+                expect(result).toBe("negative ten trillion dollars");
+            });
+
+            it("should handle 10 trillion minus 1 cent", () => {
+                const result = model.evaluator(mockTrigger, 9999999999999.99);
+                expect(result).toBe(
+                    "nine trillion nine hundred ninety-nine billion nine hundred ninety-nine million nine hundred ninety-nine thousand nine hundred ninety-nine dollars and ninety-nine cents"
+                );
+            });
+
+            it("should return empty string for just over 10 trillion with cents", () => {
+                const result = model.evaluator(mockTrigger, 10000000000000.01);
+                expect(result).toBe("");
+            });
+
+            it("should return empty string for just under -10 trillion with cents", () => {
+                const result = model.evaluator(mockTrigger, -10000000000000.01);
+                expect(result).toBe("");
+            });
+        });
+
+        describe("edge cases for invalid divisor", () => {
+            it("should treat undefined divisor as 1", () => {
+                const result = model.evaluator(mockTrigger, 100, undefined);
+                expect(result).toBe("one hundred dollars");
+            });
+
+            it("should treat null divisor as 1", () => {
+                // biome-ignore lint/suspicious/noExplicitAny: Needed for this test
+                const result = model.evaluator(mockTrigger, 100, null as any);
+                expect(result).toBe("one hundred dollars");
+            });
+
+            it("should treat zero divisor as 1", () => {
+                const result = model.evaluator(mockTrigger, 100, 0);
+                expect(result).toBe("one hundred dollars");
+            });
+
+            it("should treat non-numeric divisor as 1", () => {
+                // biome-ignore lint/suspicious/noExplicitAny: Needed for this test
+                const result = model.evaluator(mockTrigger, 100, "abc" as any);
+                expect(result).toBe("one hundred dollars");
+            });
+
+            it("should handle negative divisor", () => {
+                const result = model.evaluator(mockTrigger, 100, -2);
+                expect(result).toBe("negative fifty dollars");
+            });
+
+            it("should handle double negative (negative amount with negative divisor)", () => {
+                const result = model.evaluator(mockTrigger, -100, -2);
+                expect(result).toBe("fifty dollars");
+            });
+        });
+
+        describe("rounding behavior", () => {
+            it("should round cents correctly from division", () => {
+                const result = model.evaluator(mockTrigger, 20, 3);
+                expect(result).toBe("six dollars and sixty-seven cents");
+            });
+
+            it("should round 20/3 correctly", () => {
+                const result = model.evaluator(mockTrigger, 20, 3);
+                expect(result).toBe("six dollars and sixty-seven cents");
+            });
+
+            it("should round 1/3 correctly", () => {
+                const result = model.evaluator(mockTrigger, 1, 3);
+                expect(result).toBe("thirty-three cents");
+            });
+
+            it("should round 100/7 correctly", () => {
+                const result = model.evaluator(mockTrigger, 100, 7);
+                expect(result).toBe("fourteen dollars and twenty-nine cents");
+            });
+
+            it("should round up cents when divisor results in 0.5 cents", () => {
+                const result = model.evaluator(mockTrigger, 1, 200);
+                expect(result).toBe("one cent");
+            });
+        });
+
+        describe("realistic scenarios", () => {
+            it("should handle streamer donation amount", () => {
+                const result = model.evaluator(mockTrigger, 420.69);
+                expect(result).toBe("four hundred twenty dollars and sixty-nine cents");
+            });
+
+            it("should handle bits to dollars (1000 bits / 100 = $10)", () => {
+                const result = model.evaluator(mockTrigger, 1000, 100);
+                expect(result).toBe("ten dollars");
+            });
+
+            it("should handle bits with cents (150 bits / 100 = $1.50)", () => {
+                const result = model.evaluator(mockTrigger, 150, 100);
+                expect(result).toBe("one dollar and fifty cents");
+            });
+
+            it("should handle million dollar amount", () => {
+                const result = model.evaluator(mockTrigger, 1000000);
+                expect(result).toBe("one million dollars");
+            });
+
+            it("should handle large real-world amount", () => {
+                const result = model.evaluator(mockTrigger, 123456789.99);
+                expect(result).toBe(
+                    "one hundred twenty-three million four hundred fifty-six thousand seven hundred eighty-nine dollars and ninety-nine cents"
+                );
+            });
+        });
+    });
+});

--- a/src/variables/format-usd-text.ts
+++ b/src/variables/format-usd-text.ts
@@ -1,0 +1,272 @@
+import type { Effects } from "@crowbartools/firebot-custom-scripts-types/types/effects";
+import type { ReplaceVariable } from "@crowbartools/firebot-custom-scripts-types/types/modules/replace-variable-manager";
+
+// Lookup tables for number-to-words conversion
+const ones = [
+	"zero",
+	"one",
+	"two",
+	"three",
+	"four",
+	"five",
+	"six",
+	"seven",
+	"eight",
+	"nine",
+];
+
+const teens = [
+	"ten",
+	"eleven",
+	"twelve",
+	"thirteen",
+	"fourteen",
+	"fifteen",
+	"sixteen",
+	"seventeen",
+	"eighteen",
+	"nineteen",
+];
+
+const tens = [
+	"",
+	"",
+	"twenty",
+	"thirty",
+	"forty",
+	"fifty",
+	"sixty",
+	"seventy",
+	"eighty",
+	"ninety",
+];
+
+const scales = [
+	{ value: 1000000000000, name: "trillion" },
+	{ value: 1000000000, name: "billion" },
+	{ value: 1000000, name: "million" },
+	{ value: 1000, name: "thousand" },
+];
+
+/**
+ * Convert a number 0-999 to words
+ */
+function convertBelowThousand(num: number): string {
+	if (num === 0) {
+		return "";
+	}
+
+	let result = "";
+
+	// Handle hundreds
+	const hundreds = Math.floor(num / 100);
+	if (hundreds > 0) {
+		result += `${ones[hundreds]} hundred`;
+		num %= 100;
+		if (num > 0) {
+			result += " ";
+		}
+	}
+
+	// Handle tens and ones
+	if (num >= 20) {
+		result += tens[Math.floor(num / 10)];
+		const remainder = num % 10;
+		if (remainder > 0) {
+			result += `-${ones[remainder]}`;
+		}
+	} else if (num >= 10) {
+		result += teens[num - 10];
+	} else if (num > 0) {
+		result += ones[num];
+	}
+
+	return result;
+}
+
+/**
+ * Convert a number to its word representation for text-to-speech
+ */
+function convertToWords(num: number): string {
+	if (num === 0) {
+		return "zero";
+	}
+
+	let result = "";
+
+	// Handle each scale
+	for (const scale of scales) {
+		const scaleValue = Math.floor(num / scale.value);
+		if (scaleValue > 0) {
+			if (result) {
+				result += " ";
+			}
+			result += `${convertBelowThousand(scaleValue)} ${scale.name}`;
+			num %= scale.value;
+		}
+	}
+
+	// Handle remaining ones
+	if (num > 0) {
+		if (result) {
+			result += " ";
+		}
+		result += convertBelowThousand(num);
+	}
+
+	return result;
+}
+
+/**
+ * Parse amount and divisor as strings to preserve precision,
+ * then divide and return result as fixed-point string with 2 decimal places.
+ */
+function divideWithPrecision(
+	amountStr: string,
+	divisorStr: string,
+): { result: string; isNegative: boolean } {
+	// Remove non-numeric chars except minus, decimal, digits
+	const cleanAmount = amountStr.replace(/[^0-9.-]/g, "").replace(/(?!^)-/g, "");
+	const cleanDivisor = divisorStr
+		.replace(/[^0-9.-]/g, "")
+		.replace(/(?!^)-/g, "");
+
+	// Determine if result is negative
+	const amountNegative = cleanAmount.startsWith("-");
+	const divisorNegative = cleanDivisor.startsWith("-");
+	const isNegative = amountNegative !== divisorNegative;
+
+	// Handle divisor of 0 or invalid
+	const divisorNum = Number(cleanDivisor);
+	if (isNaN(divisorNum) || divisorNum === 0) {
+		const amountNum = Number(cleanAmount);
+		const absAmount = Math.abs(amountNum);
+		return { result: absAmount.toFixed(2), isNegative: amountNum < 0 };
+	}
+
+	// Use BigInt for precision: multiply by 100 to get cents, divide, then format
+	const absAmountStr = cleanAmount.replace(/^-/, "");
+	const absDivisorStr = cleanDivisor.replace(/^-/, "");
+
+	// Parse as cents (multiply by 100)
+	const parseToCents = (s: string): bigint => {
+		const parts = s.split(".");
+		if (parts.length === 1) {
+			return BigInt(parts[0] || "0") * BigInt(100);
+		}
+		const intPart = parts[0] || "0";
+		const decPart = parts[1].padEnd(2, "0").slice(0, 2);
+		return BigInt(intPart) * BigInt(100) + BigInt(decPart);
+	};
+
+	const amountCents = parseToCents(absAmountStr);
+	const divisorCents = parseToCents(absDivisorStr);
+
+	// Divide with rounding: (amountCents * 100 * 2 + divisorCents) / (divisorCents * 2)
+	const numerator = amountCents * BigInt(200) + divisorCents;
+	const denominator = divisorCents * BigInt(2);
+	const quotient = numerator / denominator;
+
+	// Format as dollars.cents
+	const dollars = quotient / BigInt(100);
+	const cents = quotient % BigInt(100);
+	const result = `${dollars}.${cents.toString().padStart(2, "0")}`;
+
+	return { result, isNegative };
+}
+
+const model: ReplaceVariable = {
+	definition: {
+		handle: "formatUSDText",
+		usage: "formatUSDText[amount, divisor]",
+		description:
+			"Converts a dollar amount to English words optimized for text-to-speech (TTS). Optionally divides by a divisor before converting. Supports amounts from -10 trillion to 10 trillion inclusive.",
+		categories: ["advanced"],
+		possibleDataOutput: ["text"],
+		examples: [
+			{
+				usage: "formatUSDText[420.69]",
+				description:
+					"Converts to: four hundred twenty dollars and sixty-nine cents",
+			},
+			{
+				usage: "formatUSDText[100]",
+				description: "Converts to: one hundred dollars",
+			},
+			{
+				usage: "formatUSDText[-200.4]",
+				description:
+					"Converts to: negative two hundred dollars and forty cents",
+			},
+			{
+				usage: "formatUSDText[10000, 100]",
+				description:
+					"Divides 10000 by 100 and converts to: one hundred dollars",
+			},
+		],
+	},
+	evaluator: (
+		trigger: Effects.Trigger,
+		amount?: string | number,
+		divisor?: string | number,
+	): string => {
+		const amountStr = String(amount ?? "");
+		const divisorStr = String(divisor ?? "");
+
+		// Handle empty/invalid amount
+		if (!amountStr || isNaN(Number(amountStr.replace(/[^0-9.-]/g, "")))) {
+			return "zero dollars";
+		}
+
+		// Perform division with precision
+		const { result: fixedStr, isNegative } = divideWithPrecision(
+			amountStr,
+			divisorStr,
+		);
+
+		// Split into dollars and cents
+		const [dollarPart, centPart] = fixedStr.split(".");
+		const dollars = parseInt(dollarPart, 10);
+		const cents = parseInt(centPart, 10);
+
+		// Range validation: supported range is -10 trillion to 10 trillion inclusive
+		// 10 trillion = 10,000,000,000,000 = 1,000,000,000,000,000 cents
+		const maxDollars = 10000000000000;
+		const maxCents = maxDollars * 100;
+		const totalCents = Math.abs(dollars) * 100 + cents;
+		if (totalCents > maxCents) {
+			return "";
+		}
+
+		// Special case: only cents (no dollars)
+		if (dollars === 0 && cents > 0) {
+			let result = convertToWords(cents);
+			result += cents === 1 ? " cent" : " cents";
+			if (isNegative) {
+				result = `negative ${result}`;
+			}
+			return result;
+		}
+
+		// Convert dollars to words
+		let result = convertToWords(dollars);
+
+		// Add dollar/dollars
+		result += dollars === 1 ? " dollar" : " dollars";
+
+		// Add cents if present
+		if (cents > 0) {
+			result += ` and ${convertToWords(cents)}`;
+			result += cents === 1 ? " cent" : " cents";
+		}
+
+		// Add negative prefix if needed (but not for zero)
+		if (isNegative && (dollars !== 0 || cents !== 0)) {
+			result = `negative ${result}`;
+		}
+
+		return result;
+	},
+};
+
+export default model;

--- a/src/variables/format-usd-text.ts
+++ b/src/variables/format-usd-text.ts
@@ -3,118 +3,118 @@ import type { ReplaceVariable } from "@crowbartools/firebot-custom-scripts-types
 
 // Lookup tables for number-to-words conversion
 const ones = [
-	"zero",
-	"one",
-	"two",
-	"three",
-	"four",
-	"five",
-	"six",
-	"seven",
-	"eight",
-	"nine",
+    "zero",
+    "one",
+    "two",
+    "three",
+    "four",
+    "five",
+    "six",
+    "seven",
+    "eight",
+    "nine"
 ];
 
 const teens = [
-	"ten",
-	"eleven",
-	"twelve",
-	"thirteen",
-	"fourteen",
-	"fifteen",
-	"sixteen",
-	"seventeen",
-	"eighteen",
-	"nineteen",
+    "ten",
+    "eleven",
+    "twelve",
+    "thirteen",
+    "fourteen",
+    "fifteen",
+    "sixteen",
+    "seventeen",
+    "eighteen",
+    "nineteen"
 ];
 
 const tens = [
-	"",
-	"",
-	"twenty",
-	"thirty",
-	"forty",
-	"fifty",
-	"sixty",
-	"seventy",
-	"eighty",
-	"ninety",
+    "",
+    "",
+    "twenty",
+    "thirty",
+    "forty",
+    "fifty",
+    "sixty",
+    "seventy",
+    "eighty",
+    "ninety"
 ];
 
 const scales = [
-	{ value: 1000000000000, name: "trillion" },
-	{ value: 1000000000, name: "billion" },
-	{ value: 1000000, name: "million" },
-	{ value: 1000, name: "thousand" },
+    { value: 1000000000000, name: "trillion" },
+    { value: 1000000000, name: "billion" },
+    { value: 1000000, name: "million" },
+    { value: 1000, name: "thousand" }
 ];
 
 /**
  * Convert a number 0-999 to words
  */
 function convertBelowThousand(num: number): string {
-	if (num === 0) {
-		return "";
-	}
+    if (num === 0) {
+        return "";
+    }
 
-	let result = "";
+    let result = "";
 
-	// Handle hundreds
-	const hundreds = Math.floor(num / 100);
-	if (hundreds > 0) {
-		result += `${ones[hundreds]} hundred`;
-		num %= 100;
-		if (num > 0) {
-			result += " ";
-		}
-	}
+    // Handle hundreds
+    const hundreds = Math.floor(num / 100);
+    if (hundreds > 0) {
+        result += `${ones[hundreds]} hundred`;
+        num %= 100;
+        if (num > 0) {
+            result += " ";
+        }
+    }
 
-	// Handle tens and ones
-	if (num >= 20) {
-		result += tens[Math.floor(num / 10)];
-		const remainder = num % 10;
-		if (remainder > 0) {
-			result += `-${ones[remainder]}`;
-		}
-	} else if (num >= 10) {
-		result += teens[num - 10];
-	} else if (num > 0) {
-		result += ones[num];
-	}
+    // Handle tens and ones
+    if (num >= 20) {
+        result += tens[Math.floor(num / 10)];
+        const remainder = num % 10;
+        if (remainder > 0) {
+            result += `-${ones[remainder]}`;
+        }
+    } else if (num >= 10) {
+        result += teens[num - 10];
+    } else if (num > 0) {
+        result += ones[num];
+    }
 
-	return result;
+    return result;
 }
 
 /**
  * Convert a number to its word representation for text-to-speech
  */
 function convertToWords(num: number): string {
-	if (num === 0) {
-		return "zero";
-	}
+    if (num === 0) {
+        return "zero";
+    }
 
-	let result = "";
+    let result = "";
 
-	// Handle each scale
-	for (const scale of scales) {
-		const scaleValue = Math.floor(num / scale.value);
-		if (scaleValue > 0) {
-			if (result) {
-				result += " ";
-			}
-			result += `${convertBelowThousand(scaleValue)} ${scale.name}`;
-			num %= scale.value;
-		}
-	}
+    // Handle each scale
+    for (const scale of scales) {
+        const scaleValue = Math.floor(num / scale.value);
+        if (scaleValue > 0) {
+            if (result) {
+                result += " ";
+            }
+            result += `${convertBelowThousand(scaleValue)} ${scale.name}`;
+            num %= scale.value;
+        }
+    }
 
-	// Handle remaining ones
-	if (num > 0) {
-		if (result) {
-			result += " ";
-		}
-		result += convertBelowThousand(num);
-	}
+    // Handle remaining ones
+    if (num > 0) {
+        if (result) {
+            result += " ";
+        }
+        result += convertBelowThousand(num);
+    }
 
-	return result;
+    return result;
 }
 
 /**
@@ -122,151 +122,151 @@ function convertToWords(num: number): string {
  * then divide and return result as fixed-point string with 2 decimal places.
  */
 function divideWithPrecision(
-	amountStr: string,
-	divisorStr: string,
+    amountStr: string,
+    divisorStr: string
 ): { result: string; isNegative: boolean } {
-	// Remove non-numeric chars except minus, decimal, digits
-	const cleanAmount = amountStr.replace(/[^0-9.-]/g, "").replace(/(?!^)-/g, "");
-	const cleanDivisor = divisorStr
-		.replace(/[^0-9.-]/g, "")
-		.replace(/(?!^)-/g, "");
+    // Remove non-numeric chars except minus, decimal, digits
+    const cleanAmount = amountStr.replace(/[^0-9.-]/g, "").replace(/(?!^)-/g, "");
+    const cleanDivisor = divisorStr
+        .replace(/[^0-9.-]/g, "")
+        .replace(/(?!^)-/g, "");
 
-	// Determine if result is negative
-	const amountNegative = cleanAmount.startsWith("-");
-	const divisorNegative = cleanDivisor.startsWith("-");
-	const isNegative = amountNegative !== divisorNegative;
+    // Determine if result is negative
+    const amountNegative = cleanAmount.startsWith("-");
+    const divisorNegative = cleanDivisor.startsWith("-");
+    const isNegative = amountNegative !== divisorNegative;
 
-	// Handle divisor of 0 or invalid
-	const divisorNum = Number(cleanDivisor);
-	if (isNaN(divisorNum) || divisorNum === 0) {
-		const amountNum = Number(cleanAmount);
-		const absAmount = Math.abs(amountNum);
-		return { result: absAmount.toFixed(2), isNegative: amountNum < 0 };
-	}
+    // Handle divisor of 0 or invalid
+    const divisorNum = Number(cleanDivisor);
+    if (isNaN(divisorNum) || divisorNum === 0) {
+        const amountNum = Number(cleanAmount);
+        const absAmount = Math.abs(amountNum);
+        return { result: absAmount.toFixed(2), isNegative: amountNum < 0 };
+    }
 
-	// Use BigInt for precision: multiply by 100 to get cents, divide, then format
-	const absAmountStr = cleanAmount.replace(/^-/, "");
-	const absDivisorStr = cleanDivisor.replace(/^-/, "");
+    // Use BigInt for precision: multiply by 100 to get cents, divide, then format
+    const absAmountStr = cleanAmount.replace(/^-/, "");
+    const absDivisorStr = cleanDivisor.replace(/^-/, "");
 
-	// Parse as cents (multiply by 100)
-	const parseToCents = (s: string): bigint => {
-		const parts = s.split(".");
-		if (parts.length === 1) {
-			return BigInt(parts[0] || "0") * BigInt(100);
-		}
-		const intPart = parts[0] || "0";
-		const decPart = parts[1].padEnd(2, "0").slice(0, 2);
-		return BigInt(intPart) * BigInt(100) + BigInt(decPart);
-	};
+    // Parse as cents (multiply by 100)
+    const parseToCents = (s: string): bigint => {
+        const parts = s.split(".");
+        if (parts.length === 1) {
+            return BigInt(parts[0] || "0") * BigInt(100);
+        }
+        const intPart = parts[0] || "0";
+        const decPart = parts[1].padEnd(2, "0").slice(0, 2);
+        return BigInt(intPart) * BigInt(100) + BigInt(decPart);
+    };
 
-	const amountCents = parseToCents(absAmountStr);
-	const divisorCents = parseToCents(absDivisorStr);
+    const amountCents = parseToCents(absAmountStr);
+    const divisorCents = parseToCents(absDivisorStr);
 
-	// Divide with rounding: (amountCents * 100 * 2 + divisorCents) / (divisorCents * 2)
-	const numerator = amountCents * BigInt(200) + divisorCents;
-	const denominator = divisorCents * BigInt(2);
-	const quotient = numerator / denominator;
+    // Divide with rounding: (amountCents * 100 * 2 + divisorCents) / (divisorCents * 2)
+    const numerator = amountCents * BigInt(200) + divisorCents;
+    const denominator = divisorCents * BigInt(2);
+    const quotient = numerator / denominator;
 
-	// Format as dollars.cents
-	const dollars = quotient / BigInt(100);
-	const cents = quotient % BigInt(100);
-	const result = `${dollars}.${cents.toString().padStart(2, "0")}`;
+    // Format as dollars.cents
+    const dollars = quotient / BigInt(100);
+    const cents = quotient % BigInt(100);
+    const result = `${dollars}.${cents.toString().padStart(2, "0")}`;
 
-	return { result, isNegative };
+    return { result, isNegative };
 }
 
 const model: ReplaceVariable = {
-	definition: {
-		handle: "formatUSDText",
-		usage: "formatUSDText[amount, divisor]",
-		description:
+    definition: {
+        handle: "formatUSDText",
+        usage: "formatUSDText[amount, divisor]",
+        description:
 			"Converts a dollar amount to English words optimized for text-to-speech (TTS). Optionally divides by a divisor before converting. Supports amounts from -10 trillion to 10 trillion inclusive.",
-		categories: ["advanced"],
-		possibleDataOutput: ["text"],
-		examples: [
-			{
-				usage: "formatUSDText[420.69]",
-				description:
-					"Converts to: four hundred twenty dollars and sixty-nine cents",
-			},
-			{
-				usage: "formatUSDText[100]",
-				description: "Converts to: one hundred dollars",
-			},
-			{
-				usage: "formatUSDText[-200.4]",
-				description:
-					"Converts to: negative two hundred dollars and forty cents",
-			},
-			{
-				usage: "formatUSDText[10000, 100]",
-				description:
-					"Divides 10000 by 100 and converts to: one hundred dollars",
-			},
-		],
-	},
-	evaluator: (
-		trigger: Effects.Trigger,
-		amount?: string | number,
-		divisor?: string | number,
-	): string => {
-		const amountStr = String(amount ?? "");
-		const divisorStr = String(divisor ?? "");
+        categories: ["advanced"],
+        possibleDataOutput: ["text"],
+        examples: [
+            {
+                usage: "formatUSDText[420.69]",
+                description:
+					"Converts to: four hundred twenty dollars and sixty-nine cents"
+            },
+            {
+                usage: "formatUSDText[100]",
+                description: "Converts to: one hundred dollars"
+            },
+            {
+                usage: "formatUSDText[-200.4]",
+                description:
+					"Converts to: negative two hundred dollars and forty cents"
+            },
+            {
+                usage: "formatUSDText[10000, 100]",
+                description:
+					"Divides 10000 by 100 and converts to: one hundred dollars"
+            }
+        ]
+    },
+    evaluator: (
+        trigger: Effects.Trigger,
+        amount?: string | number,
+        divisor?: string | number
+    ): string => {
+        const amountStr = String(amount ?? "");
+        const divisorStr = String(divisor ?? "");
 
-		// Handle empty/invalid amount
-		if (!amountStr || isNaN(Number(amountStr.replace(/[^0-9.-]/g, "")))) {
-			return "zero dollars";
-		}
+        // Handle empty/invalid amount
+        if (!amountStr || isNaN(Number(amountStr.replace(/[^0-9.-]/g, "")))) {
+            return "zero dollars";
+        }
 
-		// Perform division with precision
-		const { result: fixedStr, isNegative } = divideWithPrecision(
-			amountStr,
-			divisorStr,
-		);
+        // Perform division with precision
+        const { result: fixedStr, isNegative } = divideWithPrecision(
+            amountStr,
+            divisorStr
+        );
 
-		// Split into dollars and cents
-		const [dollarPart, centPart] = fixedStr.split(".");
-		const dollars = parseInt(dollarPart, 10);
-		const cents = parseInt(centPart, 10);
+        // Split into dollars and cents
+        const [dollarPart, centPart] = fixedStr.split(".");
+        const dollars = parseInt(dollarPart, 10);
+        const cents = parseInt(centPart, 10);
 
-		// Range validation: supported range is -10 trillion to 10 trillion inclusive
-		// 10 trillion = 10,000,000,000,000 = 1,000,000,000,000,000 cents
-		const maxDollars = 10000000000000;
-		const maxCents = maxDollars * 100;
-		const totalCents = Math.abs(dollars) * 100 + cents;
-		if (totalCents > maxCents) {
-			return "";
-		}
+        // Range validation: supported range is -10 trillion to 10 trillion inclusive
+        // 10 trillion = 10,000,000,000,000 = 1,000,000,000,000,000 cents
+        const maxDollars = 10000000000000;
+        const maxCents = maxDollars * 100;
+        const totalCents = Math.abs(dollars) * 100 + cents;
+        if (totalCents > maxCents) {
+            return "";
+        }
 
-		// Special case: only cents (no dollars)
-		if (dollars === 0 && cents > 0) {
-			let result = convertToWords(cents);
-			result += cents === 1 ? " cent" : " cents";
-			if (isNegative) {
-				result = `negative ${result}`;
-			}
-			return result;
-		}
+        // Special case: only cents (no dollars)
+        if (dollars === 0 && cents > 0) {
+            let result = convertToWords(cents);
+            result += cents === 1 ? " cent" : " cents";
+            if (isNegative) {
+                result = `negative ${result}`;
+            }
+            return result;
+        }
 
-		// Convert dollars to words
-		let result = convertToWords(dollars);
+        // Convert dollars to words
+        let result = convertToWords(dollars);
 
-		// Add dollar/dollars
-		result += dollars === 1 ? " dollar" : " dollars";
+        // Add dollar/dollars
+        result += dollars === 1 ? " dollar" : " dollars";
 
-		// Add cents if present
-		if (cents > 0) {
-			result += ` and ${convertToWords(cents)}`;
-			result += cents === 1 ? " cent" : " cents";
-		}
+        // Add cents if present
+        if (cents > 0) {
+            result += ` and ${convertToWords(cents)}`;
+            result += cents === 1 ? " cent" : " cents";
+        }
 
-		// Add negative prefix if needed (but not for zero)
-		if (isNegative && (dollars !== 0 || cents !== 0)) {
-			result = `negative ${result}`;
-		}
+        // Add negative prefix if needed (but not for zero)
+        if (isNegative && (dollars !== 0 || cents !== 0)) {
+            result = `negative ${result}`;
+        }
 
-		return result;
-	},
+        return result;
+    }
 };
 
 export default model;

--- a/src/variables/index.ts
+++ b/src/variables/index.ts
@@ -1,17 +1,18 @@
-import { firebot } from '../main';
-import closestMatch from './closest-match';
-import degreesToDirection from './degrees-to-direction';
-import ensureArray from './ensure-array';
-import fileNameWithExtension from './file-name-with-extension';
-import filenamesInDirectory from './filenames-in-directory';
-import flattenArray from './flatten-array';
-import formatUSD from './format-usd';
-import haversineDistance from './haversine-distance';
-import metersToMiles from './meters-to-miles';
-import milesToMeters from './miles-to-meters';
-import streamUptime from './stream-uptime';
-import travelBearing from './travel-bearing';
-import uFuzzyMatch from './ufuzzy-match';
+import { firebot } from "../main";
+import closestMatch from "./closest-match";
+import degreesToDirection from "./degrees-to-direction";
+import ensureArray from "./ensure-array";
+import fileNameWithExtension from "./file-name-with-extension";
+import filenamesInDirectory from "./filenames-in-directory";
+import flattenArray from "./flatten-array";
+import formatUSD from "./format-usd";
+import formatUSDText from "./format-usd-text";
+import haversineDistance from "./haversine-distance";
+import metersToMiles from "./meters-to-miles";
+import milesToMeters from "./miles-to-meters";
+import streamUptime from "./stream-uptime";
+import travelBearing from "./travel-bearing";
+import uFuzzyMatch from "./ufuzzy-match";
 
 export function registerReplaceVariables() {
     const { replaceVariableManager } = firebot.modules;
@@ -23,6 +24,7 @@ export function registerReplaceVariables() {
     replaceVariableManager.registerReplaceVariable(fileNameWithExtension);
     replaceVariableManager.registerReplaceVariable(flattenArray);
     replaceVariableManager.registerReplaceVariable(formatUSD);
+    replaceVariableManager.registerReplaceVariable(formatUSDText);
     replaceVariableManager.registerReplaceVariable(haversineDistance);
     replaceVariableManager.registerReplaceVariable(metersToMiles);
     replaceVariableManager.registerReplaceVariable(milesToMeters);


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Add `$formatUSDText` variable which formats a number into text.

e.g. `$formatUSDText[420.69] => "four hundred twenty dollars and sixty-nine cents"`

This is for making TTS more deterministic with dollar amounts.

### Motivation
<!-- Please describe WHY you are making this change. This may include links to GitHub issues if relevant. -->

### Testing
<!-- Outline any testing you've done for these changes. You may provide screen shots, copy/paste from logs, etc. as evidence. -->
